### PR TITLE
Optimize distributeRewards gas consumption by 30%

### DIFF
--- a/contracts/tests/TestERC20.sol
+++ b/contracts/tests/TestERC20.sol
@@ -34,4 +34,12 @@ contract TestERC20 is ERC20 {
 
         return super.transfer(to, value);
     }
+
+    function transferFrom(address from, address to, uint256 value) public returns (bool) {
+        if (failTransfer) {
+            return false;
+        }
+
+        return super.transferFrom(from, to, value);
+    }
 }


### PR DESCRIPTION
When profiling distribution rewards to 20 stake owners:
Before: ~1,624,000 gas
After: ~1,135,000 gas